### PR TITLE
chore(license): update to JSF standard license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,5 @@
-(The MIT License)
 
-Copyright (c) 2014-2016 Tobias Koppers
+Copyright JS Foundation and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
- Previous Copyright holder is Tobias, this was transferred with the initial group to JSF