### PR TITLE
Made comments valid CSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 module.exports = function() {
 	this.cacheable();
-	return "// empty (null-loader)";
+	return "/* empty (null-loader) */";
 };
 module.exports.pitch = function() {
 	this.cacheable();
-	return "// empty (null-loader)";
+	return "/* empty (null-loader) */";
 };


### PR DESCRIPTION
`//` Isn't a valid comment for CSS which meant that the loaded couldn't be
used when loading CSS. Simple fix is to use `/* .. */` which is valid in both rather than attempting to detect the type being loaded.