### PR TITLE
feat: added support for .css files imported by Js modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import validateOptions from 'schema-utils';
 import schema from './options.json';
 
 export default function() {
-  return '// empty (null-loader)';
+  return '/* empty (null-loader) */';
 }
 
 export function pitch() {
@@ -12,5 +12,5 @@ export function pitch() {
 
   validateOptions(schema, options, 'Null Loader');
 
-  return '// empty (null-loader)';
+  return '/* empty (null-loader) */';
 }

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -96,7 +96,7 @@ exports[`null-loader should works 1`] = `
 /*! no static exports found */
 /***/ (function(module, exports) {
 
-// empty (null-loader)
+/* empty (null-loader) */
 
 /***/ })
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

In some scenarios, such as the one I encountered at my current company, a JS module may import a `.css` file and then webpack will process it with say, postcss-loader & css-loader.

If you need to nullify that `.css` file using this loader, the output of null-loader won't be valid CSS since CSS does not support single line comments `// ...` and thus, css-loader or postcss-loader will throw an error (SyntaxError) and webpack will stop bundling. 

Since both CSS and JS support multi-line or block comments `/* ... */` I think it's sensible to use this form instead of single line comments.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
